### PR TITLE
Allow nested clients (e.g. DynamoDB.DocumentClient) to be unmocked, then remocked

### DIFF
--- a/aws-sdk.js
+++ b/aws-sdk.js
@@ -5,7 +5,10 @@ const _AWS = jest.requireActual('aws-sdk');
 const traverse = require('traverse');
 
 Object.keys(_AWS).forEach((service) => {
-  AWS[service] = _AWS[service];
+  AWS[service] = {};
+  Object.keys(_AWS[service]).forEach((key) => {
+    AWS[service][key] = _AWS[service][key];
+  });
 });
 
 const clients = {};

--- a/test/mock.test.js
+++ b/test/mock.test.js
@@ -146,7 +146,7 @@ describe('stubbing', () => {
 
     AWS.clearAllMocks();
     const ddb = new AWS.DynamoDB.DocumentClient();
-    expect(jest.isMockFunction(ddb)).toEqual(false);
+    expect(jest.isMockFunction(ddb.get)).toEqual(false);
     expect(AWS['DynamoDB.DocumentClient']).toEqual(undefined);
   });
 });


### PR DESCRIPTION
The problem @drboyer demonstrated in #2 was due to the fact that this library tries to store unmocked versions of clients, and put those back onto `AWS.` when you call `clearAllMocks`. The mocked clients are on `AWS.` and the unmocked ones are on `_AWS`.

The prior code would end up with 

```js
AWS.DynamoDB == _AWS.DynamoDB
```

Two equals signs intended -- these both referenced the same in-memory location. So when `AWS.DynamoDB.DocumentClient` was changed to a mock, that also changed `_AWS.DynamoDB.DocumentClient`. During `clearAllMocks`, the mocked client from `_AWS` gets put back into the `AWS`. To solve this, `AWS.DynamoDB` has to be its own object, so that when its `.DocumentClient` is changed, that doesn't touch the real one under `_AWS`.

The tests also had a bug -- checking that the `new DynamoDB.DocumentClient()` wasn't a mock was a bad test -- it should've tested whether the previously mocked `get` function on that client was a mock.

Lastly, I'm not aware of any SDK clients nested 3 layers deep (like `AWS.DynamoDB.DocumentClient.SomethingDeeper`, but if there is such a thing, this'd still expose the same issue.

Fixes #2
cc @andreapark 
