### PR TITLE
When a nested client is mocked, the top-level client becomes invalid

### DIFF
--- a/test/mock.test.js
+++ b/test/mock.test.js
@@ -45,7 +45,7 @@ describe('stubbing', () => {
 
     AWS.clearAllMocks();
     const after = new AWS.S3();
-    expect(jest.isMockFunction('after.putObject')).toEqual(false);
+    expect(jest.isMockFunction(after.putObject)).toEqual(false);
     expect(jest.isMockFunction(after.getObject)).toEqual(false);
   });
 

--- a/test/mock.test.js
+++ b/test/mock.test.js
@@ -45,7 +45,7 @@ describe('stubbing', () => {
 
     AWS.clearAllMocks();
     const after = new AWS.S3();
-    expect(jest.isMockFunction(after.putObject)).toEqual(false);
+    expect(jest.isMockFunction('after.putObject')).toEqual(false);
     expect(jest.isMockFunction(after.getObject)).toEqual(false);
   });
 
@@ -152,5 +152,30 @@ describe('stubbing', () => {
     const ddb = new AWS.DynamoDB.DocumentClient();
     expect(jest.isMockFunction(ddb.get)).toEqual(false);
     expect(AWS['DynamoDB.DocumentClient']).toEqual(undefined);
+  });
+
+  it('can mock both top-level and nested clients', async () => {
+    const getItem = AWS.spyOnPromise('DynamoDB', 'getItem', {
+      Item: { key: 'getItem' }
+    });
+    const get = AWS.spyOnPromise('DynamoDB.DocumentClient', 'get', {
+      Item: { key: 'get' }
+    });
+
+    const ddb = new AWS.DynamoDB({ region: 'us-west-3' });
+    const ddbResult = await ddb.getItem({ Key: { key: 'getItem' } }).promise();
+    expect(ddbResult).toEqual({ Item: { key: 'getItem' } });
+    expect(getItem).toHaveBeenCalledTimes(1);
+    expect(get).toHaveBeenCalledTimes(0);
+    expect(getItem).toHaveBeenCalledWith({ Key: { key: 'getItem' } });
+
+    const docClient = new AWS.DynamoDB.DocumentClient({ region: 'us-west-3' });
+    const docClientResult = await docClient
+      .get({ Key: { key: 'get' } })
+      .promise();
+    expect(docClientResult).toEqual({ Item: { key: 'get' } });
+    expect(getItem).toHaveBeenCalledTimes(1);
+    expect(get).toHaveBeenCalledTimes(1);
+    expect(get).toHaveBeenCalledWith({ Key: { key: 'get' } });
   });
 });

--- a/test/mock.test.js
+++ b/test/mock.test.js
@@ -144,6 +144,10 @@ describe('stubbing', () => {
     expect(result).toStrictEqual({ key: 'value', data: 'stuff' });
     expect(get).toHaveBeenCalledWith({ Key: { key: 'value' } });
 
+    expect(() => {
+      new AWS.DynamoDB();
+    }).not.toThrow();
+
     AWS.clearAllMocks();
     const ddb = new AWS.DynamoDB.DocumentClient();
     expect(jest.isMockFunction(ddb.get)).toEqual(false);


### PR DESCRIPTION
After spying on the `AWS.DynamoDB.DocumentClient`'s `.get()` method ...

```js
    const get = AWS.spyOnPromise('DynamoDB.DocumentClient', 'get', {
      key: 'value',
      data: 'stuff'
    });
```

... the `AWS.DynamoDB` "top-level" client breaks:

```js
    // this fails with "AWS.DynamoDB is not a constructor", but should pass
    expect(() => {
      new AWS.DynamoDB();
    }).not.toThrow();
```

Not sure yet how to solve the problem, but this addition to the test suite reproduces the failure.

cc @springmeyer 