### PR TITLE
Fix function property assignment

### DIFF
--- a/aws-sdk.js
+++ b/aws-sdk.js
@@ -19,9 +19,7 @@ for (const key of Object.keys(_AWS)) {
       return realValue.apply(this, arguments);
     };
     AWS[key].prototype = realValue.prototype;
-    for (const funcKey of Object.keys(realValue)) {
-      AWS[key] = realValue[funcKey];
-    }
+    Object.assign(AWS[key], realValue);
   } else {
     AWS[key] = realValue;
   }
@@ -37,11 +35,11 @@ clients.get = (service) => {
   if (!clients[service]) clients[service] = new real({});
   const client = clients[service];
 
-  if (!jest.isMockFunction(mocked))
-    traverse(AWS).set(
-      split,
-      jest.fn().mockImplementation(() => client)
-    );
+  if (!jest.isMockFunction(mocked)) {
+    const mock = jest.fn().mockImplementation(() => client);
+    Object.assign(mock, real);
+    traverse(AWS).set(split, mock);
+  }
 
   return client;
 };

--- a/readme.md
+++ b/readme.md
@@ -154,5 +154,12 @@ describe('listing things', () => {
 - If you try to mock a method twice, you will get an error.
 - For nested clients like `AWS.DynamoDB.DocumentClient`, you can mock methods like this: `AWS.spyOn('DynamoDB.DocumentClient', 'get')`.
 - You should be familiar with the [AWS.Request][1] object, because if your code needs to set special expectations for `.promise()`, `.eachPage()`, or `.on()`, then you're going to have to use `AWS.spyOn()` and provide your own implementations for those Request methods.
+- If your application is using [`dyno`][2] ... don't! Use `AWS.DynamoDB.DocumentClient`, instead! But if you must, you'll need to mock the nested paths of the `aws-sdk` that `dyno` uses:
+  ```js
+  jest.mock('aws-sdk/lib/dynamodb/set', () => jest.fn());
+  jest.mock('aws-sdk/lib/dynamodb/converter', () => jest.fn());
+  ```
 
 [1]: https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Request.html
+
+[2]: https://github.com/mapbox/dyno

--- a/test/mock.test.js
+++ b/test/mock.test.js
@@ -166,6 +166,7 @@ describe('stubbing', () => {
       Item: { key: 'get' }
     });
 
+    expect(jest.isMockFunction(AWS.DynamoDB)).toEqual(true);
     expect(jest.isMockFunction(AWS.DynamoDB.DocumentClient)).toEqual(true);
     expect(AWS.DynamoDB.Converter).toBe(RealAWS.DynamoDB.Converter);
 


### PR DESCRIPTION
In the prior PR, I wasn't assigning function properties correctly. I ended up overriding `AWS.DynamoDB` with `AWS.DynamoDB.DocumentClient`. In this PR, I fix that and add some documentation about what you need to do if you're still using `dyno`.